### PR TITLE
Update Python package metadata syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,14 @@
 [metadata]
 name = audresample
 author = Johannes Wagner, Andrea Crespi, Hagen Wierstorf
-author-email = jwagner@audeering.com, acrespi@audeering.com, hwierstorf@audeering.com
+author_email = jwagner@audeering.com, acrespi@audeering.com, hwierstorf@audeering.com
 url = https://github.com/audeering/audresample/
-project-urls =
+project_urls =
     Documentation = https://audeering.github.io/audresample/
 description = Provides functions to resample and remix a signal
-long-description = file: README.rst, CHANGELOG.rst
+long_description = file: README.rst, CHANGELOG.rst
 license = MIT
-license-file = LICENSE
+license_file = LICENSE
 keywords = audio, dsp, resample, remix
 platforms= any
 classifiers =


### PR DESCRIPTION
Replace deprecated `abc-def` entries with `abc_def` in `setup.cfg`.