### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,13 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 1.0.0 (2022-01-04)
+--------------------------
+
+* Added: Python 3.9 support
+* Removed: Python 3.6 support
+
+
 Version 0.1.6 (2021-06-17)
 --------------------------
 


### PR DESCRIPTION
As I don't think we will changing the API of `audresample`, maybe it's time to make a `1.0.0` release?