### PR TITLE
Add support for float64 in audresample.remix()

### DIFF
--- a/audresample/core/api.py
+++ b/audresample/core/api.py
@@ -97,8 +97,7 @@ def remix(
     The workflow of :func:`audresample.remix` is always
     upmix -> channel selection -> downmix.
 
-    The returned signal always is of type ``np.float32``
-    with shape (``channels``, ``samples``).
+    The returned signal always of shape (``channels``, ``samples``).
 
     Args:
         signal: array with signal values

--- a/audresample/core/api.py
+++ b/audresample/core/api.py
@@ -17,8 +17,6 @@ def _check_signal(
             f"Input signal must have 1 or 2 dimension, "
             f"got {signal.ndim}."
         )
-    if signal.dtype != np.float32:
-        signal = signal.astype(np.float32)
     return np.atleast_2d(signal)
 
 
@@ -207,6 +205,10 @@ def resample(
 
     """
     signal = _check_signal(signal)
+
+    # We can only handle float32 signals
+    if signal.dtype != np.float32:
+        signal = signal.astype(np.float32)
 
     if original_rate == target_rate or signal.size == 0:
         if always_copy:

--- a/audresample/core/api.py
+++ b/audresample/core/api.py
@@ -158,18 +158,7 @@ def remix(
 
     num_channels = signal.shape[0]
     if mixdown and num_channels > 1:
-        num_samples = signal.shape[1]
-        # as a side-effect of storing channel first
-        # we need to transpose and flatten the channel in memory
-        signal = signal.transpose().ravel()
-        signal_mono = np.empty((1, num_samples), dtype=np.float32)
-        lib.do_mono_mixdown(
-            signal_mono.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
-            signal.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
-            int(num_samples),
-            int(num_channels),
-        )
-        return signal_mono
+        return np.atleast_2d(np.mean(signal, axis=0))
 
     if always_copy:
         return signal.copy()

--- a/tests/test_remix.py
+++ b/tests/test_remix.py
@@ -350,8 +350,6 @@ def test_remix_signal(
         upmix=upmix,
         always_copy=always_copy,
     )
-    print(signal)
-    print(result)
     assert signal.dtype == expect.dtype
     np.testing.assert_equal(result, expect)
     if (

--- a/tests/test_remix.py
+++ b/tests/test_remix.py
@@ -246,6 +246,14 @@ def mixdown(signal):
             mixdown(audresample.am_fm_synth(16000, 2, 16000)),
         ),
         (
+            np.zeros((3, 16000), dtype='float64'),
+            None,
+            True,
+            None,
+            False,
+            np.zeros((1, 16000), dtype='float64'),
+        ),
+        (
             audresample.am_fm_synth(16000, 3, 16000),
             [0, 1],
             True,
@@ -326,6 +334,8 @@ def test_remix_signal(
         upmix=upmix,
         always_copy=always_copy,
     )
+    print(signal)
+    print(result)
     assert signal.dtype == expect.dtype
     np.testing.assert_equal(result, expect)
     if (

--- a/tests/test_remix.py
+++ b/tests/test_remix.py
@@ -1,3 +1,4 @@
+import ctypes
 from glob import glob
 from os import path
 
@@ -14,7 +15,21 @@ def set_ones(signal, channels):
 
 
 def mixdown(signal):
-    return np.atleast_2d(np.mean(signal, axis=0))
+    signal = np.atleast_2d(signal)
+    num_channels = signal.shape[0]
+    if num_channels < 2:
+        return signal
+    else:
+        num_samples = signal.shape[1]
+        signal = signal.transpose().ravel()
+        signal_mono = np.empty((1, num_samples), dtype=np.float32)
+        audresample.core.lib.lib.do_mono_mixdown(
+            signal_mono.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+            signal.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
+            int(num_samples),
+            int(num_channels),
+        )
+        return np.atleast_2d(signal_mono)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_remix.py
+++ b/tests/test_remix.py
@@ -23,6 +23,7 @@ def mixdown(signal):
         num_samples = signal.shape[1]
         signal = signal.transpose().ravel()
         signal_mono = np.empty((1, num_samples), dtype=np.float32)
+        # Mixdown like it is done in devAIce
         audresample.core.lib.lib.do_mono_mixdown(
             signal_mono.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),
             signal.ctypes.data_as(ctypes.POINTER(ctypes.c_float)),

--- a/tests/test_remix.py
+++ b/tests/test_remix.py
@@ -71,12 +71,12 @@ def mixdown(signal):
         ),
         # single channel
         (
-            np.zeros((16000,)),
+            np.zeros((16000,), dtype=np.float64),
             None,
             False,
             None,
             False,
-            np.zeros((1, 16000), dtype=np.float32),
+            np.zeros((1, 16000), dtype=np.float64),
         ),
         (
             np.zeros((1, 16000), np.float32),
@@ -165,12 +165,12 @@ def mixdown(signal):
         ),
         # multiple channels
         (
-            set_ones(np.zeros((4, 16000), np.float32), 2),
+            set_ones(np.zeros((4, 16000), np.float64), 2),
             2,
             False,
             None,
             False,
-            np.ones((1, 16000), dtype=np.float32),
+            np.ones((1, 16000), dtype=np.float64),
         ),
         (
             set_ones(np.zeros((4, 16000), np.float32), -1),
@@ -262,6 +262,14 @@ def mixdown(signal):
             True,
             np.zeros((1, 16000), dtype=np.float32),
         ),
+        (
+            np.zeros((1, 16000), dtype=np.float64),
+            None,
+            False,
+            None,
+            True,
+            np.zeros((1, 16000), dtype=np.float64),
+        ),
         # wrong channel index
         pytest.param(
             np.zeros((2, 16000)),
@@ -303,7 +311,7 @@ def mixdown(signal):
         ),
     ]
 )
-def test_resample_signal(
+def test_remix_signal(
         signal,
         channels,
         mixdown,
@@ -318,11 +326,14 @@ def test_resample_signal(
         upmix=upmix,
         always_copy=always_copy,
     )
+    assert signal.dtype == expect.dtype
     np.testing.assert_equal(result, expect)
-    if signal.size > 0 and\
-            channels is None and\
-            not mixdown and\
-            signal.dtype == np.float32:
+    if (
+            signal.size > 0
+            and channels is None
+            and not mixdown
+            and signal.ndim == 2
+    ):
         if always_copy:
             assert id(signal) != id(result)
         else:


### PR DESCRIPTION
Closes #15 
Alternative implementation to https://github.com/audeering/audresample/pull/16

`audresample.remix()` works totally fine with other data types than `float32`, so we don't need to restrict it.

The reason why it was retricted to float32 before was the usage of `lib.do_mono_mixdown()` from the C library for mixdown, but do we really need to use it?