### PR TITLE
Raise error if dtype not float32 in resample()

### DIFF
--- a/audresample/core/api.py
+++ b/audresample/core/api.py
@@ -175,7 +175,7 @@ def resample(
 ) -> np.ndarray:
     r"""Resample signal to a new sampling rate.
 
-    Supports only single precision signals (e.g. datatype float32).
+    Supports only signals in single precision floating point format.
     The returned signal is always of shape (``channels``, ``samples``).
 
     Args:

--- a/audresample/core/api.py
+++ b/audresample/core/api.py
@@ -175,8 +175,8 @@ def resample(
 ) -> np.ndarray:
     r"""Resample signal to a new sampling rate.
 
-    The returned signal is always of type ``np.float32``
-    with shape (``channels``, ``samples``).
+    Supports only single precision signals (e.g. datatype float32).
+    The returned signal is always of shape (``channels``, ``samples``).
 
     Args:
         signal: array with signal values
@@ -190,13 +190,17 @@ def resample(
 
     Raises:
         RuntimeError: if input signal has more than two dimensions
+        RuntimeError: if input type is not :class:`numpy.single`
 
     """
     signal = _check_signal(signal)
 
     # We can only handle float32 signals
     if signal.dtype != np.float32:
-        signal = signal.astype(np.float32)
+        raise RuntimeError(
+            'Input signal must be of type float32/single, '
+            f'got {signal.dtype}.'
+        )
 
     if original_rate == target_rate or signal.size == 0:
         if always_copy:

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -22,9 +22,6 @@ resampled_wavs = glob('tests/test-assets/resampled__*.wav')
         ),
         # original_rate == target_rate without copy
         (
-            np.zeros((16000,)), 16000, 16000, False,
-        ),
-        (
             np.zeros((16000,), dtype=np.float32), 16000, 16000, False,
         ),
         (
@@ -35,9 +32,6 @@ resampled_wavs = glob('tests/test-assets/resampled__*.wav')
         ),
         # original_rate == target_rate with copy
         (
-            np.zeros((16000,)), 16000, 16000, True,
-        ),
-        (
             np.zeros((16000,), dtype=np.float32), 16000, 16000, True,
         ),
         (
@@ -47,9 +41,6 @@ resampled_wavs = glob('tests/test-assets/resampled__*.wav')
             np.zeros((16000, 3), dtype=np.float32), 16000, 16000, True,
         ),
         # original_rate != target_rate
-        (
-            np.zeros((16000,)), 16000, 8000, False,
-        ),
         (
             np.zeros((16000,), dtype=np.float32), 16000, 8000, False,
         ),
@@ -66,7 +57,16 @@ resampled_wavs = glob('tests/test-assets/resampled__*.wav')
         pytest.param(
             np.zeros((16000, 2, 3)), 16000, 16000, False,
             marks=pytest.mark.xfail(raises=RuntimeError),
-        )
+        ),
+        # wrong input datatype
+        pytest.param(
+            np.zeros((16000,), dtype=np.float64), 16000, 16000, False,
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        pytest.param(
+            np.zeros((16000,), dtype=int), 16000, 16000, False,
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
     ]
 )
 def test_resample_signal(signal, original_rate, target_rate, always_copy):


### PR DESCRIPTION
Closes #16 

![image](https://user-images.githubusercontent.com/173624/152216905-e9d14b96-8818-4989-9e1c-b46d7b76e6d0.png)

I phrased it with `np.single` and mention float32 only as an example as it seems to be bound to the Linux x86_64 platform, compare https://numpy.org/doc/stable/reference/arrays.scalars.html#numpy.single