### PR TITLE
DOC: add datatype limit of resample() to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ audresample
 Python wrapper for `audresamplelib`_
 that provides functions to
 resample and remix audio signals.
-The resampling library does only support
+Resampling is only supported for
 single precision signals.
 
 Have a look at the installation_ and usage_ instructions.

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ audresample
 Python wrapper for `audresamplelib`_
 that provides functions to
 resample and remix audio signals.
+The resampling library does only support
+single precision signals.
 
 Have a look at the installation_ and usage_ instructions.
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Python wrapper for `audresamplelib`_
 that provides functions to
 resample and remix audio signals.
 Resampling is only supported for
-single precision signals.
+signals in single precision floating-point format.
 
 Have a look at the installation_ and usage_ instructions.
 


### PR DESCRIPTION
I think we should mention the limitations of the resampling library on the landing page/README.

![image](https://user-images.githubusercontent.com/173624/152306211-f9a35b77-cd08-4a92-81d9-398a893e04d4.png)
