### PR TITLE
DOC: disable auto-listing of API entries

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,10 @@ autodoc_mock_imports = [
     'numpy',
 ]
 
+# Disable auto-generation of TOC entries in the API
+# https://github.com/sphinx-doc/sphinx/issues/6316
+toc_object_entries = False
+
 # HTML --------------------------------------------------------------------
 
 html_theme = 'sphinx_audeering_theme'


### PR DESCRIPTION
As done in https://github.com/audeering/audinterface/pull/80 for audinterafce this fixes the TOC entries for API in the documentation. sphinx introuced this new feature with a recent version and made it default even though it is not in a good state yet in my opinion.