### PR TITLE
DOC: add example to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,13 @@ audresample
 
 Small library to remix or resample your signals.
 
+Have a look at the installation_ and usage_ instructions.
+
 .. code-block:: python
 
+    >>> import numpy as np
+    >>> import audresample
+    >>> signal = np.zeros((2, 8000), dtype='float32')
     >>> signal.shape
     (2, 8000)
     >>> audresample.remix(signal, mixdown=True).shape
@@ -22,12 +27,10 @@ signals in single precision floating-point format,
 and based on the `soxr`_ implementation
 as provided by `audresamplelib`_,
 
-Have a look at the installation_ and usage_ instructions.
-
-.. _soxr: https://sourceforge.net/projects/soxr/
-.. _audresamplelib: https://github.com/audeering/audresamplelib
 .. _installation: https://audeering.github.io/audresample/install.html
 .. _usage: https://audeering.github.io/audresample/usage.html
+.. _soxr: https://sourceforge.net/projects/soxr/
+.. _audresamplelib: https://github.com/audeering/audresamplelib
 
 
 .. badges images and links:

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,11 @@ audresample
 
 **audresample** remixes or resamples your signals.
 
+Resampling is supported
+for signals in single precision floating-point format,
+and based on the `soxr`_ implementation
+as provided by `audresamplelib`_.
+
 Have a look at the installation_ and usage_ instructions.
 
 .. code-block:: python
@@ -16,21 +21,16 @@ Have a look at the installation_ and usage_ instructions.
     >>> signal.shape
     (2, 8000)
     >>> audresample.remix(signal, mixdown=True).shape
-    (2, 8000)
+    (1, 8000)
     >>> audresample.remix(signal, channels=[0, 0, 1, 1]).shape
     (4, 8000)
     >>> audresample.resample(signal, 8000, 16000).shape
     (2, 16000)
 
-Resampling is only supported for
-signals in single precision floating-point format,
-and based on the `soxr`_ implementation
-as provided by `audresamplelib`_,
-
-.. _installation: https://audeering.github.io/audresample/install.html
-.. _usage: https://audeering.github.io/audresample/usage.html
 .. _soxr: https://sourceforge.net/projects/soxr/
 .. _audresamplelib: https://github.com/audeering/audresamplelib
+.. _installation: https://audeering.github.io/audresample/install.html
+.. _usage: https://audeering.github.io/audresample/usage.html
 
 
 .. badges images and links:

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@ audresample
 
 |tests| |coverage| |docs| |python-versions| |license|
 
-Small library to remix or resample your signals.
+**audresample** remixes or resamples your signals.
 
 Have a look at the installation_ and usage_ instructions.
 

--- a/README.rst
+++ b/README.rst
@@ -4,14 +4,27 @@ audresample
 
 |tests| |coverage| |docs| |python-versions| |license|
 
-Python wrapper for `audresamplelib`_
-that provides functions to
-resample and remix audio signals.
+Small library to remix or resample your signals.
+
+.. code-block:: python
+
+    >>> signal.shape
+    (2, 8000)
+    >>> audresample.remix(signal, mixdown=True).shape
+    (2, 8000)
+    >>> audresample.remix(signal, channels=[0, 0, 1, 1]).shape
+    (4, 8000)
+    >>> audresample.resample(signal, 8000, 16000).shape
+    (2, 16000)
+
 Resampling is only supported for
-signals in single precision floating-point format.
+signals in single precision floating-point format,
+and based on the `soxr`_ implementation
+as provided by `audresamplelib`_,
 
 Have a look at the installation_ and usage_ instructions.
 
+.. _soxr: https://sourceforge.net/projects/soxr/
 .. _audresamplelib: https://github.com/audeering/audresamplelib
 .. _installation: https://audeering.github.io/audresample/install.html
 .. _usage: https://audeering.github.io/audresample/usage.html


### PR DESCRIPTION
* Mention that `soxr` is used, but only for resampling
* Add short example to make functionality visible at a glance

![image](https://github.com/audeering/audresample/assets/173624/cf254812-baf4-4301-a620-d9d4a901c425)
