### PR TITLE
CI: fix typo in publish Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,14 +55,14 @@ jobs:
     
     steps:
 
+    - name: Clone repository
+      uses: actions/checkout@v3
+
     - name: Download dist artifacts
       uses: actions/download-artifact@v3
       with:
         name: artifact
         path: dist
-
-    steps:
-    - uses: actions/checkout@v3
 
     - name: Set up Python
       uses: actions/setup-python@v4


### PR DESCRIPTION
Ensures the repository is cloned in the `deploy` part of the `publish` Action.