### PR TITLE
CI: fix MacOS wheels versions in deploy action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         platform:
-        - macosx_12_0_x86_64
-        - macosx_12_0_arm64
+        - macosx_10_4_x86_64
+        - macosx_11_0_arm64
         - manylinux_2_17_x86_64
         - manylinux_2_17_armv7l
         - manylinux_2_17_aarch64


### PR DESCRIPTION
In https://github.com/audeering/audresample/pull/44 we changed the versions of the MacOS wheels, but forgot to update the `publish` Action on Github as well, as there we need to manually list the supported tags.