### PR TITLE
CI: fix changelog in Github release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,9 @@ jobs:
 
     - name: Clone repository
       uses: actions/checkout@v3
+      # Need depth to get diff for changelog
+      with:
+        fetch-depth: 1
 
     - name: Download dist artifacts
       uses: actions/download-artifact@v3


### PR DESCRIPTION
In https://github.com/audeering/audresample/pull/42 we made sure that the repository is cloned when building the docs, but we also need to fetch the commit before to be able to get a proper changelog in the Github releases and not what we get at the moment:

![image](https://github.com/audeering/audresample/assets/173624/2baee168-e388-4bdf-b95b-ee34ae2b7fae)
