### PR TITLE
DOC: add ipykernel to dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 audeer >=1.18.0
+ipykernel
 jupyter-sphinx
 matplotlib
 sphinx


### PR DESCRIPTION
`ipykernel` is no longer automatically installed with `jupyter-sphinx`.