### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
             python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.12'
+          - os: ubuntu-latest
+            python-version: '3.13'
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [


### PR DESCRIPTION
Add Python 3.13 to `pyproejct.toml` and add a test for it.

## Summary by Sourcery

Add support for Python 3.13 by updating the CI workflow and project metadata

Enhancements:
- Add Python 3.13 classifier to project metadata

CI:
- Include Python 3.13 in GitHub Actions test matrix