### PR TITLE
CI: fix uploading multiple artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
+        name: python-wheels-${{ matrix.platform }}
         path: ./wheelhouse/*
 
   deploy:
@@ -71,8 +72,9 @@ jobs:
     - name: Download dist artifacts
       uses: actions/download-artifact@v4
       with:
-        name: artifact
+        pattern: python-wheels*
         path: wheelhouse
+        merge-multiple: true
 
     - name: Set up Python
       uses: actions/setup-python@v5


### PR DESCRIPTION
It's no longer possible to upload several artifacts (here wheels) using the same name for the artifact.

We switch here to a solution proposed at https://github.com/actions/upload-artifact/discussions/469#discussioncomment-7992109.

## Summary by Sourcery

Fix CI workflow to upload and download multiple wheel artifacts by naming uploads per platform and merging downloads using pattern matching

Bug Fixes:
- Allow uploading multiple wheel artifacts by assigning unique names per platform

CI:
- Set artifact upload name to include the platform matrix variable
- Use pattern matching with merge-multiple=true when downloading artifacts