### PR TITLE
DOC: mention uvx in install instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,10 +5,13 @@ Install the :mod:`audresample` Python package with:
 
 .. code-block:: bash
 
-    $ # Create and activate Python virtual environment, e.g.
-    $ # virtualenv --no-download --python=python3 ${HOME}/.envs/audresample
-    $ # source ${HOME}/.envs/audresample/bin/activate
     $ pip install audresample
+
+To interactively test it run:
+
+.. code-block:: bash
+
+    $ uvx --with audresample ipython
 
 :mod:`audresample` comes with a pre-built binary of the `audresamplelib`_.
 


### PR DESCRIPTION
Extend installation instructions.

![image](https://github.com/user-attachments/assets/6cf51284-144b-4d2f-a564-c7fdcf9c5a3c)
