### PR TITLE
Include only audresample* in Python package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,7 @@ convention = 'google'
 include-package-data = false
 # Find all (sub-)modules of the Python package
 [tool.setuptools.packages.find]
+include = ['audresample*']
 
 
 # ----- setuptools_scm ----------------------------------------------------


### PR DESCRIPTION
This restricts the files included in the Python package to `audresample*`.

Same fix as audeering/audb#560 (audeering/audb#559): the empty `[tool.setuptools.packages.find]` defaults to `namespaces = true`, causing setuptools to also pick up `tests/`, `docs/`, `benchmarks/`, and `build/` as top-level namespace packages. They end up installed under `site-packages/` and shadow any local `tests/` or `docs/` packages in downstream projects.