### PR TITLE
Use sybil for doctests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ as provided by `audresamplelib`_.
 
 Have a look at the installation_ and usage_ instructions.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> import numpy as np
     >>> import audresample

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,8 +42,18 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
-    "jupyter_sphinx",
+    "matplotlib.sphinxext.plot_directive",  # include resulting figures in doc
 ]
+
+# Do not copy prompt output when using the "copy to clipboard" button
+copybutton_prompt_text = r">>> |\.\.\. "
+copybutton_prompt_is_regexp = True
+
+# Matplotlib plot_directive settings
+plot_include_source = True
+plot_html_show_source_link = False
+plot_html_show_formats = False
+plot_formats = ["png"]
 
 napoleon_use_ivar = True  # List of class attributes
 autodoc_inherit_docstrings = False  # disable docstring inheritance

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -3,6 +3,7 @@ from doctest import NORMALIZE_WHITESPACE
 
 import matplotlib
 
+
 # Use a non-interactive backend to avoid opening windows during doctests
 matplotlib.use("Agg")
 

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -21,16 +21,17 @@ def plot_signal(signal, sampling_rate):
     """Plot audio signal (used inside usage.rst doctests)."""
     num_channels = signal.shape[0]
     num_samples = signal.shape[1]
-    plt.rcParams["figure.figsize"] = [12, 2 * num_channels]
-    t = np.linspace(0, num_samples / sampling_rate, num_samples)
+    figsize = (12, 2 * num_channels)
+    t = np.arange(num_samples) / sampling_rate
     if num_channels > 1:
-        fig, axs = plt.subplots(nrows=num_channels)
+        fig, axs = plt.subplots(nrows=num_channels, figsize=figsize)
         for ax, channel in zip(axs, signal):
             ax.plot(t, channel)
             ax.set_xlabel("Time / s")
             ax.set_ylabel("Magnitude")
             ax.set_ylim([-1, 1])
     else:
+        plt.figure(figsize=figsize)
         plt.plot(t, signal.squeeze())
         plt.xlabel("Time / s")
         plt.ylabel("Magnitude")

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,54 @@
+from doctest import ELLIPSIS
+from doctest import NORMALIZE_WHITESPACE
+
+import matplotlib
+
+# Use a non-interactive backend to avoid opening windows during doctests
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+from sybil import Sybil  # noqa: E402
+from sybil.parsers.rest import DocTestParser  # noqa: E402
+from sybil.parsers.rest import PythonCodeBlockParser  # noqa: E402
+
+import audresample  # noqa: E402
+import audresample.define  # noqa: E402, F401
+
+
+def plot_signal(signal, sampling_rate):
+    """Plot audio signal (used inside usage.rst doctests)."""
+    num_channels = signal.shape[0]
+    num_samples = signal.shape[1]
+    plt.rcParams["figure.figsize"] = [12, 2 * num_channels]
+    t = np.linspace(0, num_samples / sampling_rate, num_samples)
+    if num_channels > 1:
+        fig, axs = plt.subplots(nrows=num_channels)
+        for ax, channel in zip(axs, signal):
+            ax.plot(t, channel)
+            ax.set_xlabel("Time / s")
+            ax.set_ylabel("Magnitude")
+            ax.set_ylim([-1, 1])
+    else:
+        plt.plot(t, signal.squeeze())
+        plt.xlabel("Time / s")
+        plt.ylabel("Magnitude")
+        plt.ylim([-1, 1])
+    plt.tight_layout()
+
+
+def imports(namespace):
+    """Provide modules and helpers to the doctest namespace."""
+    namespace["audresample"] = audresample
+    namespace["plot_signal"] = plot_signal
+
+
+# Collect doctests
+pytest_collect_file = Sybil(
+    parsers=[
+        DocTestParser(optionflags=ELLIPSIS | NORMALIZE_WHITESPACE),
+        PythonCodeBlockParser(),
+    ],
+    patterns=["usage.rst"],
+    setup=imports,
+).pytest()

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,30 +1,33 @@
 Usage
 =====
 
-.. jupyter-execute::
-    :hide-code:
+.. plot::
+    :context: reset
+    :include-source: false
 
-    import numpy as np
     import matplotlib.pyplot as plt
+    import numpy as np
+
 
     def plot_signal(signal, sampling_rate):
         num_channels = signal.shape[0]
         num_samples = signal.shape[1]
-        plt.rcParams['figure.figsize'] = [12, 2 * num_channels]
-        t = np.linspace(0, num_samples/sampling_rate, num_samples)
+        plt.rcParams["figure.figsize"] = [12, 2 * num_channels]
+        t = np.linspace(0, num_samples / sampling_rate, num_samples)
         if num_channels > 1:
             fig, axs = plt.subplots(nrows=num_channels)
             for ax, channel in zip(axs, signal):
                 ax.plot(t, channel)
-                ax.set_xlabel('Time / s')
-                ax.set_ylabel('Magnitude')
+                ax.set_xlabel("Time / s")
+                ax.set_ylabel("Magnitude")
                 ax.set_ylim([-1, 1])
         else:
             plt.plot(t, signal.squeeze())
-            plt.xlabel('Time / s')
-            plt.ylabel('Magnitude')
+            plt.xlabel("Time / s")
+            plt.ylabel("Magnitude")
             plt.ylim([-1, 1])
         plt.tight_layout()
+
 
 Remix signal
 ------------
@@ -33,68 +36,58 @@ Create AM/FM signal with three channels
 and a sampling rate of 16kHz
 using :meth:`audresample.am_fm_synth`.
 
-.. jupyter-execute::
+.. plot::
+    :context: close-figs
 
-    import audresample
-
-    sampling_rate = 16000
-    num_samples = 16500
-    num_channels = 3
-    signal = audresample.am_fm_synth(num_samples, num_channels, sampling_rate)
-    signal.shape
-
-.. jupyter-execute::
-    :hide-code:
-
-    plot_signal(signal, sampling_rate)
+    >>> import audresample
+    >>> sampling_rate = 16000
+    >>> num_samples = 16500
+    >>> num_channels = 3
+    >>> signal = audresample.am_fm_synth(num_samples, num_channels, sampling_rate)
+    >>> signal.shape
+    (3, 16500)
+    >>> plot_signal(signal, sampling_rate)
 
 Mixdown signal to mono.
 
-.. jupyter-execute::
+.. plot::
+    :context: close-figs
 
-    mixed = audresample.remix(signal, mixdown=True)
-    mixed.shape
-
-.. jupyter-execute::
-    :hide-code:
-
-    plot_signal(mixed, sampling_rate)
+    >>> mixed = audresample.remix(signal, mixdown=True)
+    >>> mixed.shape
+    (1, 16500)
+    >>> plot_signal(mixed, sampling_rate)
 
 Select the last channel.
 
-.. jupyter-execute::
+.. plot::
+    :context: close-figs
 
-    mixed = audresample.remix(signal, channels=-1)
-    mixed.shape
-
-.. jupyter-execute::
-    :hide-code:
-
-    plot_signal(mixed, sampling_rate)
+    >>> mixed = audresample.remix(signal, channels=-1)
+    >>> mixed.shape
+    (1, 16500)
+    >>> plot_signal(mixed, sampling_rate)
 
 Select the second and first channel.
 
-.. jupyter-execute::
+.. plot::
+    :context: close-figs
 
-    mixed = audresample.remix(signal, channels=[1, 0])
-    mixed.shape
-
-.. jupyter-execute::
-    :hide-code:
-
-    plot_signal(mixed, sampling_rate)
+    >>> mixed = audresample.remix(signal, channels=[1, 0])
+    >>> mixed.shape
+    (2, 16500)
+    >>> plot_signal(mixed, sampling_rate)
 
 Mixdown first and second channel to mono.
 
-.. jupyter-execute::
+.. plot::
+    :context: close-figs
 
-    mixed = audresample.remix(signal, channels=[0, 1], mixdown=True)
-    mixed.shape
+    >>> mixed = audresample.remix(signal, channels=[0, 1], mixdown=True)
+    >>> mixed.shape
+    (1, 16500)
+    >>> plot_signal(mixed, sampling_rate)
 
-.. jupyter-execute::
-    :hide-code:
-
-    plot_signal(mixed, sampling_rate)
 
 Resample signal
 ---------------
@@ -103,31 +96,25 @@ Create AM/FM signal with two channels
 and a sampling rate of 48kHz
 using :meth:`audresample.am_fm_synth`.
 
-.. jupyter-execute::
+.. plot::
+    :context: close-figs
 
-    import audresample
-
-    original_rate = 48000
-    num_original = 16000
-    num_channels = 2
-    signal = audresample.am_fm_synth(num_original, num_channels, original_rate)
-    signal.shape
-
-.. jupyter-execute::
-    :hide-code:
-
-    plot_signal(signal, original_rate)
+    >>> original_rate = 48000
+    >>> num_original = 16000
+    >>> num_channels = 2
+    >>> signal = audresample.am_fm_synth(num_original, num_channels, original_rate)
+    >>> signal.shape
+    (2, 16000)
+    >>> plot_signal(signal, original_rate)
 
 Resample signal to 8kHz using
 :meth:`audresample.resample`.
 
-.. jupyter-execute::
+.. plot::
+    :context: close-figs
 
-    target_rate = 8000
-    resampled = audresample.resample(signal, original_rate, target_rate)
-    resampled.shape
-
-.. jupyter-execute::
-    :hide-code:
-
-    plot_signal(resampled, target_rate)
+    >>> target_rate = 8000
+    >>> resampled = audresample.resample(signal, original_rate, target_rate)
+    >>> resampled.shape
+    (2, 2667)
+    >>> plot_signal(resampled, target_rate)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -12,16 +12,17 @@ Usage
     def plot_signal(signal, sampling_rate):
         num_channels = signal.shape[0]
         num_samples = signal.shape[1]
-        plt.rcParams["figure.figsize"] = [12, 2 * num_channels]
-        t = np.linspace(0, num_samples / sampling_rate, num_samples)
+        figsize = (12, 2 * num_channels)
+        t = np.arange(num_samples) / sampling_rate
         if num_channels > 1:
-            fig, axs = plt.subplots(nrows=num_channels)
+            fig, axs = plt.subplots(nrows=num_channels, figsize=figsize)
             for ax, channel in zip(axs, signal):
                 ax.plot(t, channel)
                 ax.set_xlabel("Time / s")
                 ax.set_ylabel("Magnitude")
                 ax.set_ylim([-1, 1])
         else:
+            plt.figure(figsize=figsize)
             plt.plot(t, signal.squeeze())
             plt.xlabel("Time / s")
             plt.ylabel("Magnitude")
@@ -68,7 +69,7 @@ Select the last channel.
     (1, 16500)
     >>> plot_signal(mixed, sampling_rate)
 
-Select the second and first channel.
+Select the second and first channels.
 
 .. plot::
     :context: close-figs
@@ -78,7 +79,7 @@ Select the second and first channel.
     (2, 16500)
     >>> plot_signal(mixed, sampling_rate)
 
-Mixdown first and second channel to mono.
+Mix down the first and second channels to mono.
 
 .. plot::
     :context: close-figs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,16 +49,14 @@ documentation = 'https://audeering.github.io/audresample/'
 dev = [
     'audiofile',
     'audeer >=1.18.0',
-    'ipykernel',
-    'jupyter-sphinx',
     'matplotlib',
     'pytest',
     'pytest-cov',
-    'pytest-doctestplus',
     'sphinx',
     'sphinx-audeering-theme >=1.2.1',
     'sphinx-autodoc-typehints',
     'sphinx-copybutton',
+    'sybil',
     'toml',
 ]
 
@@ -86,7 +84,7 @@ skip = './audresample.egg-info,./build,./docs/api,./docs/_templates,./docs/examp
 cache_dir = '.cache/pytest'
 xfail_strict = true
 addopts = '''
-    --doctest-plus
+    -p no:doctest
     --cov=audresample
     --cov-fail-under=100
     --cov-report term-missing


### PR DESCRIPTION
Replaces `jupyter-sphinx` with `sybil` for testing usage documentation.